### PR TITLE
Update: Added support for Stackdriver specific logger options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ If you don't have this file yet, you can create it via [Google Cloud Platform - 
 
 Please read the documentation for the [Google\Cloud\Logging\LoggingClient](https://googlecloudplatform.github.io/google-cloud-php/#/docs/google-cloud/v0.58.1/logging/loggingclient?method=__construct) for other authentication options and further specific connection and setup.
 
+## Google\Cloud\Logging\Logger options
+
+Please read the documentation for the [Google\Cloud\Logging\Logger setup via Google\Cloud\Logging\LoggingClient](https://googlecloudplatform.github.io/google-cloud-php/#/docs/google-cloud/v0.58.1/logging/loggingclient?method=logger) for specific details about these options.
+
+
 ## Google\Cloud\Logging\Entry options
 
 Please read the documentation for the [Google\Cloud\Logging\Entry setup via Google\Cloud\Logging\Logger](http://googlecloudplatform.github.io/google-cloud-php/#/docs/google-cloud/v0.58.1/logging/logger?method=entry) for specific details about these options.

--- a/docs/laravel_laravel_v5_6.md
+++ b/docs/laravel_laravel_v5_6.md
@@ -16,6 +16,7 @@ Add the following entry to the `channels` section in the array below the existin
         'loggingClientOptions' => [
             'keyFilePath' => '/path/to/service-account-key-file.json',
         ],
+        // 'loggerOptions' => [],    
         // 'entryOptionsWrapper' => 'stackdriver'
     ],
 ]

--- a/docs/laravel_lumen_v5_6.md
+++ b/docs/laravel_lumen_v5_6.md
@@ -20,6 +20,7 @@ Make sure to have a [copy of config/logging.php from the Laravel/Laravel 5.6.* f
         'loggingClientOptions' => [
             'keyFilePath' => '/path/to/service-account-key-file.json',
         ],
+        // 'loggerOptions' => [],
         // 'entryOptionsWrapper' => 'stackdriver'
     ],
 ]

--- a/src/Laravel/CreateStackdriverLogger.php
+++ b/src/Laravel/CreateStackdriverLogger.php
@@ -17,11 +17,12 @@ class CreateStackdriverLogger
     {
         $projectId            = $config['logName']              ?? '';
         $loggingClientOptions = $config['loggingClientOptions'] ?? [];
+        $loggerOptions        = $config['loggerOptions'] ?? [];
         $entryOptionsWrapper  = $config['entryOptionsWrapper']  ?? 'stackdriver';
         $level                = $config['level']                ?? Logger::DEBUG;
         $bubble               = $config['bubble']               ?? true;
 
-        $stackdriverHandler = new StackdriverHandler($projectId, $loggingClientOptions, $entryOptionsWrapper, $level, $bubble);
+        $stackdriverHandler = new StackdriverHandler($projectId, $loggingClientOptions, $loggerOptions, $entryOptionsWrapper, $level, $bubble);
 
         $logger = new Logger('stackdriver', [$stackdriverHandler]);
 

--- a/src/StackdriverHandler.php
+++ b/src/StackdriverHandler.php
@@ -43,15 +43,16 @@ class StackdriverHandler extends AbstractProcessingHandler
     /**
      * @param string  $logName              Name of your log
      * @param array   $loggingClientOptions Google\Cloud\Logging\LoggingClient valid options
+     * @param array   $loggerOptions        Google\Cloud\Logging\LoggingClient::logger valid options
      * @param string  $entryOptionsWrapper  Array key used in the context array to take Google\Cloud\Logging\Entry options from
      * @param int     $level                The minimum logging level at which this handler will be triggered
      * @param Boolean $bubble               Whether the messages that are handled can bubble up the stack or not
      */
-    public function __construct($logName, $loggingClientOptions, $entryOptionsWrapper = 'stackdriver', $level = Logger::DEBUG, $bubble = true)
+    public function __construct($logName, $loggingClientOptions, $loggerOptions = [], $entryOptionsWrapper = 'stackdriver', $level = Logger::DEBUG, $bubble = true)
     {
         parent::__construct($level, $bubble);
 
-        $this->logger              = (new LoggingClient($loggingClientOptions))->logger($logName);
+        $this->logger              = (new LoggingClient($loggingClientOptions))->logger($logName, $loggerOptions);
         $this->formatter           = new LineFormatter('%message%');
         $this->entryOptionsWrapper = $entryOptionsWrapper;
     }


### PR DESCRIPTION
This PR is to enable the logger options for `Google\Cloud\Logging\Logger` during it's construction to provide `resource` and `label` configuration details at a less granular level than the `Google\Cloud\Logging\Entry` options.