### PR TITLE
Change dependency and update docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ $context['stackdriver'] = [
 
 If you need to, you can override this key name by setting `$entryOptionsWrapper` to your own value (string) when using `StackdriverHandler::__construct`.
 
+It is also possible to set path to credentials and project id via the global constant.
+```php
+define('GOOGLE_APPLICATION_CREDENTIALS', '/path/to/service-account-key-file.json'); 
+define('GOOGLE_CLOUD_PROJECT', 'eg-my-project-id-148223');
+```
+
 ## Pick your framework for some specific setup
 
 * [Laravel/Laravel v5.5](docs/laravel_laravel_v5_5.md)
@@ -64,10 +70,6 @@ $projectId = 'eg-my-project-id-148223';
 $loggingClientOptions = [
     'keyFilePath' => '/path/to/service-account-key-file.json'
 ];
-
-// It is also possible to set path to credentials and project id via the global constant
-define('GOOGLE_APPLICATION_CREDENTIALS', '/path/to/service-account-key-file.json'); 
-define('GOOGLE_CLOUD_PROJECT', 'eg-my-project-id-148223'); 
 
 // init handler
 $stackdriverHandler = new StackdriverHandler(

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ $loggingClientOptions = [
     'keyFilePath' => '/path/to/service-account-key-file.json'
 ];
 
+// It is also possible to set path to credentials and project id via the global constant
+define('GOOGLE_APPLICATION_CREDENTIALS', '/path/to/service-account-key-file.json'); 
+define('GOOGLE_CLOUD_PROJECT', 'eg-my-project-id-148223'); 
+
 // init handler
 $stackdriverHandler = new StackdriverHandler(
     $projectId,

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=7.0.0",
         "monolog/monolog": ">=1.23",
-        "google/cloud": ">=0.50.0"
+        "google/cloud-logging": "^1.12"
     },
     "autoload": {
         "psr-4": {

--- a/docs/laravel_laravel_v5_6.md
+++ b/docs/laravel_laravel_v5_6.md
@@ -13,9 +13,9 @@ Add the following entry to the `channels` section in the array below the existin
         'driver' => 'custom',
         'via' => CodeInternetApplications\MonologStackdriver\Laravel\CreateStackdriverLogger::class,
         'logName' => 'my-project-log',
-        'loggingClientOptions' => [
-            'keyFilePath' => '/path/to/service-account-key-file.json',
-        ],
+        // 'loggingClientOptions' => [
+        //     'keyFilePath' => '/path/to/service-account-key-file.json',
+        // ],
         // 'loggerOptions' => [],
         // 'lineFormat' => '%message%',
         // 'entryOptionsWrapper' => 'stackdriver',
@@ -26,6 +26,7 @@ Add the following entry to the `channels` section in the array below the existin
 ## .env
 
 Edit `.env` to update `LOG_CHANNEL` to `stackdriver`.
+And finally add `GOOGLE_APPLICATION_CREDENTIALS` and `GOOGLE_CLOUD_PROJECT` or use loggingClientOptions to set path to key file and project id.
 
 ```
 LOG_CHANNEL=stackdriver

--- a/docs/laravel_laravel_v5_7.md
+++ b/docs/laravel_laravel_v5_7.md
@@ -13,9 +13,9 @@ Add the following entry to the `channels` section in the array below the existin
         'driver' => 'custom',
         'via' => CodeInternetApplications\MonologStackdriver\Laravel\CreateStackdriverLogger::class,
         'logName' => 'my-project-log',
-        'loggingClientOptions' => [
-            'keyFilePath' => '/path/to/service-account-key-file.json',
-        ],
+        // 'loggingClientOptions' => [
+        //     'keyFilePath' => '/path/to/service-account-key-file.json',
+        // ],
         // 'loggerOptions' => [],
         // 'lineFormat' => '%message%',
         // 'entryOptionsWrapper' => 'stackdriver',
@@ -26,6 +26,7 @@ Add the following entry to the `channels` section in the array below the existin
 ## .env
 
 Edit `.env` to update `LOG_CHANNEL` to `stackdriver`.
+And finally add `GOOGLE_APPLICATION_CREDENTIALS` and `GOOGLE_CLOUD_PROJECT` or use loggingClientOptions to set path to key file and project id.
 
 ```
 LOG_CHANNEL=stackdriver

--- a/docs/laravel_lumen_v5_6.md
+++ b/docs/laravel_lumen_v5_6.md
@@ -17,9 +17,9 @@ Make sure to have a [copy of config/logging.php from the Laravel/Lumen-framework
         'driver' => 'custom',
         'via' => CodeInternetApplications\MonologStackdriver\Laravel\CreateStackdriverLogger::class,
         'logName' => 'my-project-log',
-        'loggingClientOptions' => [
-            'keyFilePath' => '/path/to/service-account-key-file.json',
-        ],
+        // 'loggingClientOptions' => [
+        //     'keyFilePath' => '/path/to/service-account-key-file.json',
+        // ],
         // 'loggerOptions' => [],
         // 'lineFormat' => '%message%',
         // 'entryOptionsWrapper' => 'stackdriver',
@@ -29,7 +29,8 @@ Make sure to have a [copy of config/logging.php from the Laravel/Lumen-framework
 
 ## .env
 
-Finally, edit `.env` to update `LOG_CHANNEL` to `stackdriver`.
+Edit `.env` to update `LOG_CHANNEL` to `stackdriver`.
+And finally add `GOOGLE_APPLICATION_CREDENTIALS` and `GOOGLE_CLOUD_PROJECT` or use loggingClientOptions to set path to key file and project id.
 
 ```
 LOG_CHANNEL=stackdriver

--- a/docs/laravel_lumen_v5_7.md
+++ b/docs/laravel_lumen_v5_7.md
@@ -17,9 +17,9 @@ Make sure to have a [copy of config/logging.php from the Laravel/Lumen-framework
         'driver' => 'custom',
         'via' => CodeInternetApplications\MonologStackdriver\Laravel\CreateStackdriverLogger::class,
         'logName' => 'my-project-log',
-        'loggingClientOptions' => [
-            'keyFilePath' => '/path/to/service-account-key-file.json',
-        ],
+        // 'loggingClientOptions' => [
+        //     'keyFilePath' => '/path/to/service-account-key-file.json',
+        // ],
         // 'loggerOptions' => [],
         // 'lineFormat' => '%message%',
         // 'entryOptionsWrapper' => 'stackdriver',
@@ -29,7 +29,8 @@ Make sure to have a [copy of config/logging.php from the Laravel/Lumen-framework
 
 ## .env
 
-Finally, edit `.env` to update `LOG_CHANNEL` to `stackdriver`.
+Edit `.env` to update `LOG_CHANNEL` to `stackdriver`.
+And finally add `GOOGLE_APPLICATION_CREDENTIALS` and `GOOGLE_CLOUD_PROJECT` or use loggingClientOptions to set path to key file and project id.
 
 ```
 LOG_CHANNEL=stackdriver


### PR DESCRIPTION
Hello, I have a suggestion to change a dependency from "google/cloud": ">=0.50.0" to "google/cloud-logging": "^1.12". It's much liter and brings only what required. Eventually google/cloud uses same dependency internally. Also I updated the docs and included GOOGLE_APPLICATION_CREDENTIALS and GOOGLE_CLOUD_PROJECT global constants. Setting them in $loggingClientOptions is not mandatory, since google/cloud-logging (and google/cloud) hook them up internally. It's more convenient, especially in laravel.