### PR TITLE
Allow one to adjust the "global" logger options at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Please read the documentation for the [Google\Cloud\Logging\Logger setup via Goo
 
 This set of options will allow you to set the default resource type and it's related labels that apply to all the logs. Please read [Method: monitoredResourceDescriptors.list](https://cloud.google.com/logging/docs/reference/v2/rest/v2/monitoredResourceDescriptors/list) and do the "Try this API" to get a full list of the specific labels per resource.
 
+You can override these at runtime by calling `appendLoggerOptions`/`setLoggerOptions` on your `StackdriverHandler` instance.
+
 ## Google\Cloud\Logging\Entry options
 
 Please read the documentation for the [Google\Cloud\Logging\Entry setup via Google\Cloud\Logging\Logger](http://googlecloudplatform.github.io/google-cloud-php/#/docs/google-cloud/v0.61.0/logging/logger?method=entry) for specific details about these options.


### PR DESCRIPTION
This PR will allow one to adjust the `$loggerOptions` at runtime. One can set (override) options, or append options.

This can be handy for setting extra labels to use with all future log events, after a logger/StackdriverHandler has already been instantiated.

Usage:
```php
use Monolog\Logger;
use CodeInternetApplications\MonologStackdriver\StackdriverHandler;

// ( ... )

// init handler
$stackdriverHandler = new StackdriverHandler(
    $projectId,
    $loggingClientOptions
);

// init logger with StackdriverHandler
$logger = new Logger('stackdriver', [$stackdriverHandler]);

// basic info log with contextual data
$logger->info('New order', ['orderId' => 1001]);

// ( ... )

// Set labels, for all future log events
$stackdriverHandler->appendLoggerOptions('labels', [
    'order' => 'paid',
]);

$logger->info('Order updated'); // Will include the order:paid label

// ( ... )
```