### PR TITLE
Restrict packages to avoid bc breaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "monolog/monolog": ">=1.23",
-        "google/cloud": ">=0.50.0"
+        "monolog/monolog": "^1.23",
+        "google/cloud": "^0.50.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
In case of bc breaks, I've restricted the dependencies defined. Currently there was an issue with the monolog/monolog 2.*. The AbstractHandler used in StackdriverHandler has changed his return type decleration and it does not comply the used AbstractHandler.

This could be released as a patch for 1.2.*

Relates #5 