### PR TITLE
Added logName option

### DIFF
--- a/src/StackdriverHandler.php
+++ b/src/StackdriverHandler.php
@@ -38,6 +38,7 @@ class StackdriverHandler extends AbstractProcessingHandler
         'operation',
         'insertId',
         'timestamp',
+        'logName'
     ];
 
     /**


### PR DESCRIPTION
Hello,
Thanks for this package, very simple and useful. I just made one line of insertion to your code.

As explained at resource 
https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry 

we have a option called "logName" i just added that option.  This will allow us to write to diffrent files on log function.

Usage : 
```
$context['stackdriver'] = [
    'logName' => 'projects/[projectIID]/logs/[LogName]'
];
```
Note ;
normally logname format is 

projects/[projectIID]/logs/[LogName]

I can make a new pr that stores project id and fixes short format like 

```
$context['stackdriver'] = [
    'logName' => '[LogName]'
];
```

Just want to get your opinion before i digg into more. 

Thanks.