### PR TITLE
Catch Service Exception from the oauth connection of gcloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+### Composer template
+composer.phar
+/vendor/
+composer.lock
+

--- a/src/StackdriverHandler.php
+++ b/src/StackdriverHandler.php
@@ -75,7 +75,13 @@ class StackdriverHandler extends AbstractProcessingHandler
 
         $entry = $this->logger->entry($data, $options);
 
-        $this->logger->write($entry);
+        try{
+            $this->logger->write($entry);
+        } catch (\Google\Cloud\Core\Exception\ServiceException $exception) {
+            error_log("Error connecting to Google services: " . $exception->getMessage());
+        } catch(\Exception $exception) {
+            throw $exception;
+        }
     }
 
     /**


### PR DESCRIPTION
Hello, on Monday October 19, Google Cloud in the Latin American region had a problem with the Cloud Networking service. When this incident occurred, the application I am working on tried to log and it crashed all the application because it could not be logged in to google cloud. I was throwing this exception all the time, `cURL error 35: Unknown SSL protocol error in connection to oauth2.googleapis.com:443  (see http://curl.haxx.se/libcurl/c/libcurl-errors.html)`.
With this fix, you should save the error log in the system logs and not in Monolog.

PS: The status of Google Cloud from October 19, https://status.cloud.google.com/incident/cloud-networking/20010